### PR TITLE
Fix spread

### DIFF
--- a/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
@@ -3,7 +3,7 @@
 
 # Authors: A2va
 # Contributors:
-# MC Version: 1.13
+# MC Version: 1.19.4
 # Last check:
 
 # Original path: bs.location:spread
@@ -26,30 +26,33 @@
 #__________________________________________________
 # CODE
 
-# Backup
-scoreboard players operation location.spread.locX bs = @s bs.loc.x
-scoreboard players operation location.spread.locY bs = @s bs.loc.y
-scoreboard players operation location.spread.locZ bs = @s bs.loc.z
+# Centering the entity introduces an one block offset
+scoreboard players operation @s bs.in.4 = @s bs.in.0
+scoreboard players operation @s bs.in.4 -= 1 bs.const
 
-scoreboard players operation @s bs.in.6 = @s bs.in.2
-scoreboard players operation @s bs.in.6 *= 2 bs.const
-scoreboard players operation @s bs.in.6 += 1 bs.const
+# From radius to diameter
+scoreboard players operation @s bs.in.3 = @s bs.in.2 
+scoreboard players operation @s bs.in.3 *= 2 bs.const
+scoreboard players operation @s bs.in.3 += 1 bs.const
 
 #Random
-function bs.math:random
-scoreboard players operation @s bs.out.0 %= @s bs.in.6
+function bs.math:special/random
+scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
+# Compute coord on X axis
 scoreboard players set @s bs.loc.x 0
 execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x -= @s bs.out.0
 execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x /= 2 bs.const
 execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.x = @s bs.out.0
 
-scoreboard players operation @s bs.loc.x += @s bs.in.0
+# Use center x with fixed offset
+scoreboard players operation @s bs.loc.x += @s bs.in.4
 
 #Random
-function bs.math:random
-scoreboard players operation @s bs.out.0 %= @s bs.in.6
+function bs.math:special/random
+scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
+# Compute coord on Z axis
 scoreboard players set @s bs.loc.z 0
 execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z -= @s bs.out.0
 execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z /= 2 bs.const
@@ -59,9 +62,7 @@ scoreboard players operation @s bs.loc.z += @s bs.in.1
 
 execute store result score @s bs.loc.y run data get entity @s Pos[1] 1
 
-function bs.location:set
 
-# Restore
-scoreboard players operation @s bs.loc.x = location.spread.locX bs
-scoreboard players operation @s bs.loc.y = location.spread.locY bs
-scoreboard players operation @s bs.loc.z = location.spread.locZ bs
+# Tp, then tp again over the world surface and block centered
+function bs.location:set
+execute at @s positioned over world_surface align xz run tp ~0.5 ~ ~0.5

--- a/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
@@ -61,9 +61,6 @@ scoreboard players operation @s bs.loc.z += @s bs.in.5
 
 execute at @s run function bs.location:get_y
 
-scoreboard players add @s bs.loc.x 1
-scoreboard players add @s bs.loc.z 1
-
 # Tp, then tp again over the world surface and block centered
 function bs.location:set
 execute at @s positioned over world_surface align xz run tp ~0.5 ~ ~0.5

--- a/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
@@ -30,6 +30,9 @@
 scoreboard players operation @s bs.in.4 = @s bs.in.0
 scoreboard players operation @s bs.in.4 -= 1 bs.const
 
+scoreboard players operation @s bs.in.5 = @s bs.in.1
+scoreboard players operation @s bs.in.5 -= 1 bs.const
+
 # From radius to diameter
 scoreboard players operation @s bs.in.3 = @s bs.in.2 
 scoreboard players operation @s bs.in.3 *= 2 bs.const
@@ -37,7 +40,8 @@ scoreboard players operation @s bs.in.3 += 1 bs.const
 
 #Random
 function bs.math:special/random
-scoreboard players operation @s bs.out.0 %= @s bs.in.3
+execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
+execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
 # Compute coord on X axis
 scoreboard players set @s bs.loc.x 0
@@ -50,7 +54,8 @@ scoreboard players operation @s bs.loc.x += @s bs.in.4
 
 #Random
 function bs.math:special/random
-scoreboard players operation @s bs.out.0 %= @s bs.in.3
+execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
+execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
 # Compute coord on Z axis
 scoreboard players set @s bs.loc.z 0
@@ -58,10 +63,9 @@ execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs
 execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z /= 2 bs.const
 execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.z = @s bs.out.0
 
-scoreboard players operation @s bs.loc.z += @s bs.in.1
+scoreboard players operation @s bs.loc.z += @s bs.in.5
 
 execute store result score @s bs.loc.y run data get entity @s Pos[1] 1
-
 
 # Tp, then tp again over the world surface and block centered
 function bs.location:set

--- a/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
@@ -1,5 +1,5 @@
 # INFO ------------------------------------------------------------------------
-# Copyright © 2023 Gunivers Community.
+# Copyright :copyright: 2023 Gunivers Community.
 
 # Authors       : A2va
 # Contributors  : 
@@ -20,22 +20,24 @@
 
 # CODE ------------------------------------------------------------------------
 
-# Centering the entity introduces an one block offset
-scoreboard players operation @s bs.in.4 = @s bs.in.0
-scoreboard players operation @s bs.in.4 -= 1 bs.const
+scoreboard players operation #location.spread.backup.out.0 bs.data = @s bs.out.0
 
-scoreboard players operation @s bs.in.5 = @s bs.in.1
-scoreboard players operation @s bs.in.5 -= 1 bs.const
+# Centering the entity introduces an one block offset
+scoreboard players operation #location.spread.x bs.data = @s bs.in.0
+scoreboard players operation #location.spread.x bs.data -= 1 bs.const
+
+scoreboard players operation #location.spread.z bs.data = @s bs.in.1
+scoreboard players operation #location.spread.z bs.data -= 1 bs.const
 
 # From radius to diameter
-scoreboard players operation @s bs.in.3 = @s bs.in.2 
-scoreboard players operation @s bs.in.3 *= 2 bs.const
-scoreboard players operation @s bs.in.3 += 1 bs.const
+scoreboard players operation #location.spread.radius bs.data = @s bs.in.2 
+scoreboard players operation #location.spread.radius bs.data *= 2 bs.const
+scoreboard players operation #location.spread.radius bs.data += 1 bs.const
 
 #Random
 function bs.math:special/random
 execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
-execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
+execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
 
 # Compute coord on X axis
 scoreboard players set @s bs.loc.x 0
@@ -44,12 +46,12 @@ execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs
 execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.x = @s bs.out.0
 
 # Use center x with fixed offset
-scoreboard players operation @s bs.loc.x += @s bs.in.4
+scoreboard players operation @s bs.loc.x += #location.spread.x bs.data
 
 #Random
 function bs.math:special/random
 execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
-execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
+execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
 
 # Compute coord on Z axis
 scoreboard players set @s bs.loc.z 0
@@ -57,10 +59,15 @@ execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs
 execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z /= 2 bs.const
 execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.z = @s bs.out.0
 
-scoreboard players operation @s bs.loc.z += @s bs.in.5
+scoreboard players operation @s bs.loc.z += #location.spread.z bs.data
 
 execute at @s run function bs.location:get_y
+
+scoreboard players add @s bs.loc.x 1
+scoreboard players add @s bs.loc.z 1
 
 # Tp, then tp again over the world surface and block centered
 function bs.location:set
 execute at @s positioned over world_surface align xz run tp ~0.5 ~ ~0.5
+
+scoreboard players operation @s bs.out.0 = #location.spread.backup.out.0 bs.data

--- a/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
@@ -1,30 +1,24 @@
-#__________________________________________________
-# INFO     Copyright © 2021 Altearn.
+# INFO ------------------------------------------------------------------------
+# Copyright © 2023 Gunivers Community.
 
-# Authors: A2va
-# Contributors:
-# MC Version: 1.19.4
-# Last check:
+# Authors       : A2va
+# Contributors  : 
+# - Leirof
 
-# Original path: bs.location:spread
-# Parallelizable: true
-# Note: Spread an entity based on CenterX, CenterZ and Radius scores
+# Version: 2.0
+# Created: 05/03/2023 (1.19.4)
+# Last verification: 05/03/2023 (1.19.4)
+# Last modification: 05/03/2023 (1.19.4)
 
-#__________________________________________________
-# PARAMETERS
+# Original path : bs.location:spread
+# Documentation : https://bookshelf.docs.gunivers.net/en/latest/modules/location.html#spread
+# Note          : Spread an entity based on CenterX, CenterZ and Radius scores
 
-#bs.in.0: CenterX
-#bs.in.1: CenterZ
-#bs.in.2: Radius
+# INIT ------------------------------------------------------------------------
 
-#__________________________________________________
-# INIT
+# CONFIG ----------------------------------------------------------------------
 
-#__________________________________________________
-# CONFIG
-
-#__________________________________________________
-# CODE
+# CODE ------------------------------------------------------------------------
 
 # Centering the entity introduces an one block offset
 scoreboard players operation @s bs.in.4 = @s bs.in.0
@@ -65,7 +59,10 @@ execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s b
 
 scoreboard players operation @s bs.loc.z += @s bs.in.5
 
-execute store result score @s bs.loc.y run data get entity @s Pos[1] 1
+execute at @s run function bs.location:get_y
+
+scoreboard players add @s bs.loc.x 1
+scoreboard players add @s bs.loc.z 1
 
 # Tp, then tp again over the world surface and block centered
 function bs.location:set

--- a/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread.mcfunction
@@ -7,8 +7,8 @@
 
 # Version: 2.0
 # Created: 05/03/2023 (1.19.4)
-# Last verification: 05/03/2023 (1.19.4)
-# Last modification: 05/03/2023 (1.19.4)
+# Last verification: 11/03/2023 (1.19.4)
+# Last modification: 11/03/2023 (1.19.4)
 
 # Original path : bs.location:spread
 # Documentation : https://bookshelf.docs.gunivers.net/en/latest/modules/location.html#spread
@@ -22,49 +22,33 @@
 
 scoreboard players operation #location.spread.backup.out.0 bs.data = @s bs.out.0
 
-# Centering the entity introduces an one block offset
 scoreboard players operation #location.spread.x bs.data = @s bs.in.0
-scoreboard players operation #location.spread.x bs.data -= 1 bs.const
-
 scoreboard players operation #location.spread.z bs.data = @s bs.in.1
-scoreboard players operation #location.spread.z bs.data -= 1 bs.const
 
 # From radius to diameter
 scoreboard players operation #location.spread.radius bs.data = @s bs.in.2 
 scoreboard players operation #location.spread.radius bs.data *= 2 bs.const
 scoreboard players operation #location.spread.radius bs.data += 1 bs.const
 
-#Random
+# Random
 function bs.math:special/random
-execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
-execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
+scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
+scoreboard players operation @s bs.out.0 -= @s bs.in.2
 
-# Compute coord on X axis
-scoreboard players set @s bs.loc.x 0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x -= @s bs.out.0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x /= 2 bs.const
-execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.x = @s bs.out.0
-
-# Use center x with fixed offset
-scoreboard players operation @s bs.loc.x += #location.spread.x bs.data
+# Compute coord on x axis
+scoreboard players operation @s bs.loc.x = #location.spread.x bs.data
+scoreboard players operation @s bs.loc.x += @s bs.out.0
 
 #Random
 function bs.math:special/random
-execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
-execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
+scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
+scoreboard players operation @s bs.out.0 -= @s bs.in.2
 
-# Compute coord on Z axis
-scoreboard players set @s bs.loc.z 0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z -= @s bs.out.0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z /= 2 bs.const
-execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.z = @s bs.out.0
-
-scoreboard players operation @s bs.loc.z += #location.spread.z bs.data
+# Compute coord on x axis
+scoreboard players operation @s bs.loc.z = #location.spread.z bs.data
+scoreboard players operation @s bs.loc.z += @s bs.out.0
 
 execute at @s run function bs.location:get_y
-
-scoreboard players add @s bs.loc.x 1
-scoreboard players add @s bs.loc.z 1
 
 # Tp, then tp again over the world surface and block centered
 function bs.location:set

--- a/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
@@ -1,30 +1,24 @@
-#__________________________________________________
-# INFO     Copyright © 2021 Altearn.
+# INFO ------------------------------------------------------------------------
+# Copyright © 2023 Gunivers Community.
 
-# Authors: A2va
-# Contributors:
-# MC Version: 1.19.4
-# Last check:
+# Authors       : A2va
+# Contributors  : 
+# - Leirof
 
-# Original path: bs.location:spread
-# Parallelizable: true
-# Note: Spread an entity based on CenterX, CenterZ and Radius scores
+# Version: 2.0
+# Created: 05/03/2023 (1.19.4)
+# Last verification: 05/03/2023 (1.19.4)
+# Last modification: 05/03/2023 (1.19.4)
 
-#__________________________________________________
-# PARAMETERS
+# Original path : bs.location:spread
+# Documentation : https://bookshelf.docs.gunivers.net/en/latest/modules/location.html#spread
+# Note          : Spread an entity based on CenterX, CenterZ and Radius scores
 
-#bs.in.0: CenterX
-#bs.in.1: CenterZ
-#bs.in.2: Radius
+# INIT ------------------------------------------------------------------------
 
-#__________________________________________________
-# INIT
+# CONFIG ----------------------------------------------------------------------
 
-#__________________________________________________
-# CONFIG
-
-#__________________________________________________
-# CODE
+# CODE ------------------------------------------------------------------------
 
 # Centering the entity introduces an one block offset
 scoreboard players operation @s bs.in.4 = @s bs.in.0
@@ -65,8 +59,10 @@ execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s b
 
 scoreboard players operation @s bs.loc.z += @s bs.in.5
 
-execute store result score @s bs.loc.y run data get entity @s Pos[1] 1000
+execute at @s run function bs.location:get_y/accuracy/10-3
 
+scoreboard players add @s bs.loc.x 1000
+scoreboard players add @s bs.loc.z 1000
 
 # Tp, then tp again over the world surface and block centered
 function bs.location:set/accuracy/10-3

--- a/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
@@ -26,6 +26,13 @@
 #__________________________________________________
 # CODE
 
+# Centering the entity introduces an one block offset
+scoreboard players operation @s bs.in.4 = @s bs.in.0
+scoreboard players operation @s bs.in.4 -= 1000 bs.const
+
+scoreboard players operation @s bs.in.5 = @s bs.in.1
+scoreboard players operation @s bs.in.5 -= 1000 bs.const
+
 # From radius to diameter
 scoreboard players operation @s bs.in.3 = @s bs.in.2 
 scoreboard players operation @s bs.in.3 *= 2 bs.const
@@ -33,7 +40,8 @@ scoreboard players operation @s bs.in.3 += 1 bs.const
 
 #Random
 function bs.math:special/random
-scoreboard players operation @s bs.out.0 %= @s bs.in.3
+execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
+execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
 # Compute coord on X axis
 scoreboard players set @s bs.loc.x 0
@@ -46,7 +54,8 @@ scoreboard players operation @s bs.loc.x += @s bs.in.4
 
 #Random
 function bs.math:special/random
-scoreboard players operation @s bs.out.0 %= @s bs.in.3
+execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
+execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
 # Compute coord on Z axis
 scoreboard players set @s bs.loc.z 0
@@ -54,11 +63,12 @@ execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs
 execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z /= 2 bs.const
 execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.z = @s bs.out.0
 
-scoreboard players operation @s bs.loc.z += @s bs.in.1
+scoreboard players operation @s bs.loc.z += @s bs.in.5
 
-execute store result score @s bs.loc.y run data get entity @s Pos[1] 1
+execute store result score @s bs.loc.y run data get entity @s Pos[1] 1000
 
 
 # Tp, then tp again over the world surface and block centered
+tellraw @a ["",{"score":{"name":"@s","objective":"bs.loc.x"}},"/",{"score":{"name":"@s","objective":"bs.loc.z"}}]
 function bs.location:set/accuracy/10-3
 execute at @s positioned over world_surface align xz run tp ~0.5 ~ ~0.5

--- a/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
@@ -3,63 +3,62 @@
 
 # Authors: A2va
 # Contributors:
-# MC Version: 1.13
+# MC Version: 1.19.4
 # Last check:
 
 # Original path: bs.location:spread
-# Documentation: https://bs-core.readthedocs.io//entity
-# Parallelizable: <true/false/global>
+# Parallelizable: true
 # Note: Spread an entity based on CenterX, CenterZ and Radius scores
 
 #__________________________________________________
 # PARAMETERS
-#bs.in.3: CenterX
-#bs.in.4: CenterZ 
-#bs.in.4: Radius
+
+#bs.in.0: CenterX
+#bs.in.1: CenterZ
+#bs.in.2: Radius
+
 #__________________________________________________
 # INIT
-
-
-
-
-
-
-
-
-
 
 #__________________________________________________
 # CONFIG
 
 #__________________________________________________
 # CODE
-scoreboard players operation @s bs.in.6 = @s bs.in.4
-scoreboard players operation @s bs.in.6 *= 2 bs.const
-scoreboard players operation @s bs.in.6 += 1 bs.const
+
+# From radius to diameter
+scoreboard players operation @s bs.in.3 = @s bs.in.2 
+scoreboard players operation @s bs.in.3 *= 2 bs.const
+scoreboard players operation @s bs.in.3 += 1 bs.const
 
 #Random
-function bs.math:random
-scoreboard players operation @s bs.out.0 %= @s bs.in.6 
+function bs.math:special/random
+scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
-scoreboard players set @s bs.in.0 0
-execute if score @s bs.out.0 > @s bs.in.4 run scoreboard players operation @s bs.in.0 -= @s bs.out.0
-execute if score @s bs.out.0 > @s bs.in.4 run scoreboard players operation @s bs.in.0 /= 2 bs.const
-execute if score @s bs.out.0 <= @s bs.in.4 run scoreboard players operation @s bs.in.0 = @s bs.out.0
+# Compute coord on X axis
+scoreboard players set @s bs.loc.x 0
+execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x -= @s bs.out.0
+execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x /= 2 bs.const
+execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.x = @s bs.out.0
 
-scoreboard players operation @s bs.in.0 += @s bs.in.3
+# Use center x with fixed offset
+scoreboard players operation @s bs.loc.x += @s bs.in.4
 
 #Random
-function bs.math:random
-scoreboard players operation @s bs.out.0 %= @s bs.in.6 
+function bs.math:special/random
+scoreboard players operation @s bs.out.0 %= @s bs.in.3
 
-scoreboard players set @s bs.in.2 0
-execute if score @s bs.out.0 > @s bs.in.4 run scoreboard players operation @s bs.in.2 -= @s bs.out.0
-execute if score @s bs.out.0 > @s bs.in.4 run scoreboard players operation @s bs.in.2 /= 2 bs.const
-execute if score @s bs.out.0 <= @s bs.in.4 run scoreboard players operation @s bs.in.2 = @s bs.out.0
+# Compute coord on Z axis
+scoreboard players set @s bs.loc.z 0
+execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z -= @s bs.out.0
+execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z /= 2 bs.const
+execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.z = @s bs.out.0
 
-scoreboard players operation @s bs.in.2 += @s bs.in.4
+scoreboard players operation @s bs.loc.z += @s bs.in.1
 
-execute store result score @s bs.in.1 run data get entity @s Pos[1] 1
+execute store result score @s bs.loc.y run data get entity @s Pos[1] 1
 
+
+# Tp, then tp again over the world surface and block centered
 function bs.location:set/accuracy/10-3
-
+execute at @s positioned over world_surface align xz run tp ~0.5 ~ ~0.5

--- a/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
@@ -30,7 +30,7 @@ scoreboard players operation @s bs.in.5 -= 1000 bs.const
 # From radius to diameter
 scoreboard players operation @s bs.in.3 = @s bs.in.2 
 scoreboard players operation @s bs.in.3 *= 2 bs.const
-scoreboard players operation @s bs.in.3 += 1 bs.const
+scoreboard players operation @s bs.in.3 += 1000 bs.const
 
 #Random
 function bs.math:special/random

--- a/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
@@ -1,5 +1,5 @@
 # INFO ------------------------------------------------------------------------
-# Copyright © 2023 Gunivers Community.
+# Copyright :copyright: 2023 Gunivers Community.
 
 # Authors       : A2va
 # Contributors  : 
@@ -7,8 +7,8 @@
 
 # Version: 2.0
 # Created: 05/03/2023 (1.19.4)
-# Last verification: 05/03/2023 (1.19.4)
-# Last modification: 05/03/2023 (1.19.4)
+# Last verification: 11/03/2023 (1.19.4)
+# Last modification: 11/03/2023 (1.19.4)
 
 # Original path : bs.location:spread
 # Documentation : https://bookshelf.docs.gunivers.net/en/latest/modules/location.html#spread
@@ -20,50 +20,38 @@
 
 # CODE ------------------------------------------------------------------------
 
-# Centering the entity introduces an one block offset
-scoreboard players operation @s bs.in.4 = @s bs.in.0
-scoreboard players operation @s bs.in.4 -= 1000 bs.const
+scoreboard players operation #location.spread.backup.out.0 bs.data = @s bs.out.0
 
-scoreboard players operation @s bs.in.5 = @s bs.in.1
-scoreboard players operation @s bs.in.5 -= 1000 bs.const
+scoreboard players operation #location.spread.x bs.data = @s bs.in.0
+scoreboard players operation #location.spread.z bs.data = @s bs.in.1
 
 # From radius to diameter
-scoreboard players operation @s bs.in.3 = @s bs.in.2 
-scoreboard players operation @s bs.in.3 *= 2 bs.const
-scoreboard players operation @s bs.in.3 += 1000 bs.const
+scoreboard players operation #location.spread.radius bs.data = @s bs.in.2 
+scoreboard players operation #location.spread.radius bs.data *= 2 bs.const
+scoreboard players operation #location.spread.radius bs.data += 1000 bs.const
+
+# Random
+function bs.math:special/random
+scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
+scoreboard players operation @s bs.out.0 -= @s bs.in.2
+
+# Compute coord on x axis
+scoreboard players operation @s bs.loc.x = #location.spread.x bs.data
+scoreboard players operation @s bs.loc.x += @s bs.out.0
 
 #Random
 function bs.math:special/random
-execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
-execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
+scoreboard players operation @s bs.out.0 %= #location.spread.radius bs.data
+scoreboard players operation @s bs.out.0 -= @s bs.in.2
 
-# Compute coord on X axis
-scoreboard players set @s bs.loc.x 0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x -= @s bs.out.0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.x /= 2 bs.const
-execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.x = @s bs.out.0
-
-# Use center x with fixed offset
-scoreboard players operation @s bs.loc.x += @s bs.in.4
-
-#Random
-function bs.math:special/random
-execute if score @s bs.in.2 <= 0 bs.const run scoreboard players set @s bs.out.0 0
-execute if score @s bs.in.2 > 0 bs.const run scoreboard players operation @s bs.out.0 %= @s bs.in.3
-
-# Compute coord on Z axis
-scoreboard players set @s bs.loc.z 0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z -= @s bs.out.0
-execute if score @s bs.out.0 > @s bs.in.2 run scoreboard players operation @s bs.loc.z /= 2 bs.const
-execute if score @s bs.out.0 <= @s bs.in.2 run scoreboard players operation @s bs.loc.z = @s bs.out.0
-
-scoreboard players operation @s bs.loc.z += @s bs.in.5
+# Compute coord on x axis
+scoreboard players operation @s bs.loc.z = #location.spread.z bs.data
+scoreboard players operation @s bs.loc.z += @s bs.out.0
 
 execute at @s run function bs.location:get_y/accuracy/10-3
 
-scoreboard players add @s bs.loc.x 1000
-scoreboard players add @s bs.loc.z 1000
-
 # Tp, then tp again over the world surface and block centered
 function bs.location:set/accuracy/10-3
-execute at @s positioned over world_surface align xz run tp ~0.5 ~ ~0.5
+execute at @s positioned over world_surface run tp ~ ~ ~
+
+scoreboard players operation @s bs.out.0 = #location.spread.backup.out.0 bs.data

--- a/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
+++ b/datapacks/Bookshelf/data/bs.location/functions/spread/accuracy/10-3.mcfunction
@@ -69,6 +69,5 @@ execute store result score @s bs.loc.y run data get entity @s Pos[1] 1000
 
 
 # Tp, then tp again over the world surface and block centered
-tellraw @a ["",{"score":{"name":"@s","objective":"bs.loc.x"}},"/",{"score":{"name":"@s","objective":"bs.loc.z"}}]
 function bs.location:set/accuracy/10-3
 execute at @s positioned over world_surface align xz run tp ~0.5 ~ ~0.5

--- a/docs/location.md
+++ b/docs/location.md
@@ -170,23 +170,79 @@ execute as Boblennon run function bs.location:fast_set
 
 ## Spread entity
 
-`spread`: Allows to randomly teleport an entity in a given area.
+:::{tab-set}
 
-* The difference with the spreadplayers command is that this function does not teleport to the highest block, it simply does not change the Y position of the entity
-* Takes as parameters the scores `bs.in.[0,1,2]` corresponding respectively to the X and Z coordinates, as well as to the radius of the area in which the entity will be teleported.
+:::{tab-item} Normal
 
-*Example:*
+**`bs.location:spread`**
 
-Teleport to an area with a radius of 10 blocks, having as its center the
-coordinate X=15, Z=25
+Allows to randomly teleport an entity in a given area.
 
-```
-# Once
-scoreboard players set @s bs.in.0 15
-scoreboard players set @s bs.in.1 25
-scoreboard players set @s bs.in.2 10
-function bs.location:spread
-```
+:Inputs:
+
+        (execution) `as <entities>`
+        : The entities you want to spread
+
+        (score) `@s bs.in.[0,1]`
+        : Repectively the X and Z coordinates of the center of the area (in blocks)
+
+        (score) `@s bs.in.2`
+        : The radius of the area (in blocks)
+
+:Outputs:
+
+        (state) @s location
+        : The entity was moved to a random position in the area
+
+:Example:
+
+        Teleport to an area with a radius of 10 blocks, having as its center the
+        coordinate X=15, Z=25
+
+        ```
+        # Once
+        scoreboard players set @s bs.in.0 15
+        scoreboard players set @s bs.in.1 25
+        scoreboard players set @s bs.in.2 10
+        function bs.location:spread
+        ```
+
+:::
+
+:::{tab-item} Scale 3
+
+**`bs.location:spread/accuracy/10-3`**
+
+Allows to randomly teleport an entity in a given area.
+
+:Inputs:
+
+        (execution) `as <entities>`
+        : The entities you want to spread
+
+        (score) `@s bs.in.[0,1]`
+        : Repectively the X and Z coordinates of the center of the area (in milliblocks)
+
+        (score) `@s bs.in.2`
+        : The radius of the area (in milliblocks)
+
+:Outputs:
+
+        (state) @s location
+        : The entity was moved to a random position in the area
+
+:Example:
+
+        Teleport to an area with a radius of 10.003 blocks, having as its center the
+        coordinate X=15.1, Z=25.502
+
+        ```
+        # Once
+        scoreboard players set @s bs.in.0 15100
+        scoreboard players set @s bs.in.1 25502
+        scoreboard players set @s bs.in.2 10003
+        function bs.location:spread/accuracy/10-3
+        ```
 
 ---
 

--- a/docs/location.md
+++ b/docs/location.md
@@ -244,6 +244,16 @@ Allows to randomly teleport an entity in a given area.
         function bs.location:spread/accuracy/10-3
         ```
 
+```{admionition} What if we put a negative radius?
+:class: tip
+
+Obviously, it doesn't make sens to have a negative radius. However, during tests, we tried for you... and it have a surprisingly cool effect!
+
+Due to mathematical properties in the computation that are performed, if you put a negative radius, your entites will be teleported somewhere between `(x,z)` and `(x+radius,z+radius)` instead of `(x-radius,z-radius)` and `(x+radius,z+radius)`.
+
+Who knows, maybe it can be usefull for someone, so we let it as it is ^^
+```
+
 ---
 
 <div align=center>


### PR DESCRIPTION
Changements par à l'ancienne version:

* La position Y de l'entité n'est plus conservée maintenant elle se positionnera au dessus de la surface du monde.
* L'entité sera toujours centrée sur le block.

En raison de la première modification, cette fonction nécessite la version 1.19.4.