### PR TITLE
🚸 Added @s support in "message" macro

### DIFF
--- a/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
@@ -19,4 +19,8 @@ $execute as @a unless entity @s[ \
     tag=!bs.log._.debug, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._\
-] run tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [DEBUG]","color":"#CCCCCC"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+] run tag @s add bs.log.catch_log
+
+$tellraw @a[tag=catch_log] ["",{"text":"BS","color":"aqua"},{"text":" [DEBUG]","color":"#CCCCCC"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+
+tag @a remove bs.log.catch_log

--- a/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
@@ -14,7 +14,7 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute at @a unless entity @p[distance=0 \
+$execute at @a unless entity @p[distance=0, \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log._.debug, \
     tag=!bs.log._._, \

--- a/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
@@ -19,8 +19,8 @@ $execute as @a unless entity @s[ \
     tag=!bs.log._.debug, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._\
-] run tag @s add bs.log.catch_log
+] run tag @s add bs.log.catch
 
-$tellraw @a[tag=catch_log] ["",{"text":"BS","color":"aqua"},{"text":" [DEBUG]","color":"#CCCCCC"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [DEBUG]","color":"#CCCCCC"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
 
-tag @a remove bs.log.catch_log
+tag @a remove bs.log.catch

--- a/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/debug.mcfunction
@@ -14,13 +14,9 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute as @a unless entity @s[ \
+$execute at @a unless entity @p[distance=0 \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log._.debug, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._\
-] run tag @s add bs.log.catch
-
-$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [DEBUG]","color":"#CCCCCC"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
-
-tag @a remove bs.log.catch
+] run tellraw @p ["",{"text":"BS","color":"aqua"},{"text":" [DEBUG]","color":"#CCCCCC"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]

--- a/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
@@ -14,7 +14,7 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute as @s unless entity @s[ \
+$execute at @s unless entity @p[distance=0 \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log.$(feature).info, \
     tag=!bs.log.$(feature).warn, \
@@ -25,8 +25,4 @@ $execute as @s unless entity @s[ \
     tag=!bs.log._.error, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tag @s add bs.log.catch
-
-$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [ERROR]","color":"#DE382B"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
-
-tag @a remove bs.log.catch
+] run tellraw @p ["",{"text":"BS","color":"aqua"},{"text":" [ERROR]","color":"#DE382B"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]

--- a/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
@@ -25,4 +25,8 @@ $execute as @s unless entity @s[ \
     tag=!bs.log._.error, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [ERROR]","color":"#DE382B"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+] run tag @s add bs.log.catch_log
+
+$tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [ERROR]","color":"#DE382B"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+
+tag @a remove bs.log.catch_log

--- a/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
@@ -14,7 +14,7 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute at @s unless entity @p[distance=0 \
+$execute at @s unless entity @p[distance=0, \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log.$(feature).info, \
     tag=!bs.log.$(feature).warn, \

--- a/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/error.mcfunction
@@ -25,8 +25,8 @@ $execute as @s unless entity @s[ \
     tag=!bs.log._.error, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tag @s add bs.log.catch_log
+] run tag @s add bs.log.catch
 
-$tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [ERROR]","color":"#DE382B"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [ERROR]","color":"#DE382B"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
 
-tag @a remove bs.log.catch_log
+tag @a remove bs.log.catch

--- a/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
@@ -21,8 +21,8 @@ $execute as @a unless entity @s[ \
     tag=!bs.log._.debug, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tag @s add bs.log.catch_log
+] run tag @s add bs.log.catch
 
-$tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [INFO]","color":"#39B54A"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [INFO]","color":"#39B54A"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
 
-tag @a remove bs.log.catch_log
+tag @a remove bs.log.catch

--- a/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
@@ -14,15 +14,11 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute as @a unless entity @s[ \
+$execute at @a unless entity @p[distance=0 \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log.$(feature).info, \
     tag=!bs.log._.info, \
     tag=!bs.log._.debug, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tag @s add bs.log.catch
-
-$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [INFO]","color":"#39B54A"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
-
-tag @a remove bs.log.catch
+] run tellraw @p ["",{"text":"BS","color":"aqua"},{"text":" [INFO]","color":"#39B54A"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]

--- a/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
@@ -14,7 +14,7 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute at @a unless entity @p[distance=0 \
+$execute at @a unless entity @p[distance=0, \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log.$(feature).info, \
     tag=!bs.log._.info, \

--- a/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/info.mcfunction
@@ -21,4 +21,8 @@ $execute as @a unless entity @s[ \
     tag=!bs.log._.debug, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [INFO]","color":"#39B54A"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+] run tag @s add bs.log.catch_log
+
+$tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [INFO]","color":"#39B54A"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+
+tag @a remove bs.log.catch_log

--- a/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
@@ -23,4 +23,8 @@ $execute as @a unless entity @s[ \
     tag=!bs.log._.warn, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [WARN]","color":"#FFC706"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+] run tag @s add bs.log.catch_log
+
+$tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [WARN]","color":"#FFC706"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+
+tag @a remove bs.log.catch_log

--- a/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
@@ -14,7 +14,7 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute as @a unless entity @s[ \
+$execute at @a unless entity @p[distance=0 \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log.$(feature).info, \
     tag=!bs.log.$(feature).warn, \
@@ -23,8 +23,4 @@ $execute as @a unless entity @s[ \
     tag=!bs.log._.warn, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tag @s add bs.log.catch
-
-$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [WARN]","color":"#FFC706"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
-
-tag @a remove bs.log.catch
+] run tellraw @p ["",{"text":"BS","color":"aqua"},{"text":" [WARN]","color":"#FFC706"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]

--- a/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
@@ -14,7 +14,7 @@
 
 # CODE ------------------------------------------------------------------------
 
-$execute at @a unless entity @p[distance=0 \
+$execute at @a unless entity @p[distance=0, \
     tag=!bs.log.$(feature).debug, \
     tag=!bs.log.$(feature).info, \
     tag=!bs.log.$(feature).warn, \

--- a/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
+++ b/datapacks/Bookshelf/data/bs.log/functions/warn.mcfunction
@@ -23,8 +23,8 @@ $execute as @a unless entity @s[ \
     tag=!bs.log._.warn, \
     tag=!bs.log._._, \
     tag=!bs.log.$(feature)._ \
-] run tag @s add bs.log.catch_log
+] run tag @s add bs.log.catch
 
-$tellraw @s ["",{"text":"BS","color":"aqua"},{"text":" [WARN]","color":"#FFC706"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
+$tellraw @a[tag=bs.log.catch] ["",{"text":"BS","color":"aqua"},{"text":" [WARN]","color":"#FFC706"},{"text":" $(path)","color":"dark_aqua"},{"text":" > ","color":"gray"}, $(message)]
 
-tag @a remove bs.log.catch_log
+tag @a remove bs.log.catch


### PR DESCRIPTION
This pull request add the support of @s in the message.

Previously, logs behaved like this:
```
scoreboard players set @e[tag=yolo] bs.score 1
execute as @e[tag=yolo] run function bs.log:info { \
  path: 'osef', \
  feature: 'osef', \
  message: '{"text":"Score: "}, {"score":{"name":"@s","objective":"bs.score"}}' \
}
# [...] Score:
```
Because the tellraw was executed on the players that recieve the message, so the @s selector in the message doesn't take the right entity.

Now, it will work as expected
```
scoreboard players set @e[tag=yolo] bs.score 1
execute as @e[tag=yolo] run function bs.log:info { \
  path: 'osef', \
  feature: 'osef', \
  message: '{"text":"Score: "}, {"score":{"name":"@e[tag=yolo,limit=1]","objective":"bs.score"}}' \
}
# [...] Score: 1
```