### PR TITLE
fix: place the version switcher in the navbar-start

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ html_theme_options = {
         "json_url": json_url,
         "version_match": version_match,
     },
-    "navbar_center": ["version-switcher", "navbar-nav"],
+    "navbar_start":  ["navbar-logo", "version-switcher"],
     "icon_links": [
         {
             "name": "Download",


### PR DESCRIPTION
as mentioned in https://github.com/pydata/pydata-sphinx-theme/issues/1458, the header navbar goes on 2 row because the version-switcher is not an inline component anymore. I replaced it in the header-start to avoid it.