### PR TITLE
fix: rollback to simple search icon

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ html_theme_options = {
         "version_match": version_match,
     },
     "navbar_start":  ["navbar-logo", "version-switcher"],
+    "navbar_persistent": ["search-button"],
     "icon_links": [
         {
             "name": "Download",


### PR DESCRIPTION
The search-icon-field is to wide for your documentation making everything to go on 2 lines, let's see if rolling back to the regular button can be a nice workaround before we found a solution on our side.